### PR TITLE
Issue 36 - Fixing Documentation / Adding Value PreParse Checker

### DIFF
--- a/Module/Functions/Private/Get-ASTInstanceValues.ps1
+++ b/Module/Functions/Private/Get-ASTInstanceValues.ps1
@@ -3,7 +3,10 @@ function Get-ASTInstanceValues {
     param(
         [Parameter(Mandatory)]
         [System.Management.Automation.Language.CommandAst[]]
-        $InstanceValues
+        $InstanceValues,
+        [Parameter()]
+        [string]
+        $ParameterName
     )
  
     $values = [System.Collections.Generic.List[String]]::New()
@@ -17,7 +20,7 @@ function Get-ASTInstanceValues {
     forEach ($valueInstance in $InstanceValuesWithParameterNames) {
 
         $Result = 0..$valueInstance.CommandElements.count | Where-Object { 
-            ($valueInstance.CommandElements[$_].ParameterName -eq "Name") 
+            ($valueInstance.CommandElements[$_].ParameterName -eq $ParameterName) 
         }
 
         # Get the following item in the array, which will be the value of the parameter name

--- a/Module/Functions/Private/Get-ASTInstanceValues.ps1
+++ b/Module/Functions/Private/Get-ASTInstanceValues.ps1
@@ -1,0 +1,32 @@
+function Get-ASTInstanceValues {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [System.Management.Automation.Language.CommandAst[]]
+        $InstanceValues
+    )
+ 
+    $values = [System.Collections.Generic.List[String]]::New()
+
+    # Split Instances with ParameterNames and Without ParameterNames
+    $InstanceValuesWithParameterNames,$InstanceValuesWithoutParameterNames = $InstanceValues.Where({
+        $_.CommandElements.Where{$_.ParameterName}
+    }, 'Split')
+
+    # Return a list of cmdlet's that have parsed parameters into the input and capture their values
+    forEach ($valueInstance in $InstanceValuesWithParameterNames) {
+
+        $Result = 0..$valueInstance.CommandElements.count | Where-Object { 
+            ($valueInstance.CommandElements[$_].ParameterName -eq "Name") 
+        }
+
+        # Get the following item in the array, which will be the value of the parameter name
+        $values.Add($valueInstance.CommandElements[$Result+1].Value)
+
+    }
+
+    $InstanceValuesWithoutParameterNames | ForEach-Object { $values.Add( $_.CommandElements[1].Value )  }
+
+    return $values
+
+}

--- a/Module/Functions/Private/New-MVPActivity.ps1
+++ b/Module/Functions/Private/New-MVPActivity.ps1
@@ -20,6 +20,7 @@ function New-MVPActivity {
         # Activity Setup        
 
         $invokeTearDown = $false
+        $isPreParse = $true
         # Setup of Contributions and Areas
         $Script:MVPArea = $null
         $Script:ContributionAreas = [System.Collections.Generic.List[PSCustomObject]]::New()
@@ -29,9 +30,12 @@ function New-MVPActivity {
 
             #
             # Test the configuration is valid.
-            $parameterCmdlets = Test-ActivityScriptBlock $Fixture
+            $parameterCmdlets = Test-ActivityScriptBlock @PSBoundParameters
             # Test that the driver is active
             Test-SEDriver
+
+            $isPreParse = $false
+
             # Test that the MVPActivity elements is present.
             Wait-ForMVPElement
             # Create new MVPActivity. Click the Button.
@@ -93,7 +97,7 @@ function New-MVPActivity {
 
         try {
 
-            if ($invokeTearDown) {
+            if ($invokeTearDown -and (-not $isPreParse)) {
                 # Close the MVP Activity
                 Stop-MVPActivity
             }

--- a/Module/Functions/Private/Test-ActivityScriptBlock.ps1
+++ b/Module/Functions/Private/Test-ActivityScriptBlock.ps1
@@ -43,7 +43,7 @@ function Test-ActivityScriptBlock {
         # Multiple Statements of Area was defined
         Throw $LocalizedData.ErrorMissingMVPActivityAreaMultiple
     } elseif (($areaInstance.count -ne 0) -and ($null -eq $ArgumentList.Area)) {
-        $AreaValue = $areaInstance.CommandElements[1].Value
+        $AreaValue = Get-InstanceValues -InstanceValues $areaInstance  
     }
 
     # Requirement 3:
@@ -64,42 +64,21 @@ function Test-ActivityScriptBlock {
         Throw $LocalizedData.ErrorMissingMVPActivityValue
     }
 
-
     # Requirement 5:
-    # Ensure that all values are correct according to the Area
+    # Ensure that all Values added to the fixture are (required) AND are correct
 
-    $ValuesAddedToScriptblock = [System.Collections.Generic.List[String]]::New()
-
-    $valueInstancesWithParameterNames,$valueInstancesWithoutParameterNames = $valueInstances.Where({
-        $_.CommandElements.Where{$_.ParameterName}
-    }, 'Split')
-
-    # Return a list of cmdlet's that have parsed parameters into the input and capture their values
-    forEach ($valueInstance in $valueInstancesWithParameterNames) {
-
-        $Result = 0..$valueInstance.CommandElements.count | Where-Object { 
-            ($valueInstance.CommandElements[$_].ParameterName -eq "Name") 
-        }
-
-        # Get the following item in the array, which will be the value of the parameter name
-        $ValuesAddedToScriptblock.Add($valueInstance.CommandElements[$Result+1].Value)
-
-    }
-
-    $valueInstancesWithoutParameterNames | ForEach-Object { $ValuesAddedToScriptblock.Add( $_.CommandElements[1].Value )  }
-
-    # Get the HTMLFormStructure and Test for the
     $HTMLFormStructure = Get-HTMLFormStructure -Name $AreaValue
+    $ASTInstanceValues = Get-InstanceValues -InstanceValues $valueInstances
 
     $testMandatoryValues = $HTMLFormStructure | Where-Object { (
         ($_.isRequired) -and 
         (
-            ($_.Name -notin $ValuesAddedToScriptblock) -and 
-            ($_.Element -notin $ValuesAddedToScriptblock)
+            ($_.Name -notin $ASTInstanceValues) -and 
+            ($_.Element -notin $ASTInstanceValues)
         )    
     )}
 
-    $testMisnamedValues = $ValuesAddedToScriptblock | Where-Object {
+    $testMisnamedValues = $ASTInstanceValues | Where-Object {
         $_ -notin $HTMLFormStructure.Name -and 
         $_ -notin $HTMLFormStructure.Element
     }

--- a/Module/Functions/Private/Test-ActivityScriptBlock.ps1
+++ b/Module/Functions/Private/Test-ActivityScriptBlock.ps1
@@ -4,7 +4,10 @@ function Test-ActivityScriptBlock {
         # Scriptblock to invoke
         [Parameter(Mandatory)]
         [ScriptBlock]
-        $Fixture
+        $Fixture,
+        [Parameter()]
+        [HashTable]
+        $ArgumentList
     )
 
     Write-Debug "[Test-ActivityScriptBlock] Validating Scriptblock:"
@@ -19,7 +22,7 @@ function Test-ActivityScriptBlock {
     #
     # Return a list of Commands
     $CommandAst = $Fixture.ast.FindAll({$args[0] -is [System.Management.Automation.Language.CommandAst]}, $true)
-    $CommandParameters = $Fixture.ast.ParamBlock.Parameters.Name.VariablePath.UserPath
+    $AreaValue = $null
 
     # Requirement 1:
     # Ensure that there are no additional MVPActivity scriptblocks within it.
@@ -30,22 +33,25 @@ function Test-ActivityScriptBlock {
     # Requirement 2:
     # Ensure that a Area is present and it's a single instance.
     $areaInstance = $CommandAst -match $LocalizedData.TestActivityRegexMVPArea
-    if (($areaInstance.count -eq 0) -and ($CommandParameters -notcontains 'Area')) {
+    if (($areaInstance.count -eq 0) -and ($null -eq $ArgumentList.Area)) {
         # No Instances were found
         Throw $LocalizedData.ErrorMissingMVPActivityArea
-    } elseif (($areaInstance.count -eq 0) -and ($CommandParameters -contains 'Area')) {
+    } elseif (($areaInstance.count -eq 0) -and ($null -ne $ArgumentList.Area)) {
         $resultObject.ParametrizedArea = $true
+        $AreaValue = $ArgumentList.Area
     } elseif ($areaInstance.count -ne 1 ) {
         # Multiple Statements of Area was defined
         Throw $LocalizedData.ErrorMissingMVPActivityAreaMultiple
+    } elseif (($areaInstance.count -ne 0) -and ($null -eq $ArgumentList.Area)) {
+        $AreaValue = $areaInstance.CommandElements[1].Value
     }
 
     # Requirement 3:
     # Ensure that the ContributionArea is present and that there is a maximum of two contributions.
     $MVPContributionArea = $CommandAst -match $LocalizedData.TestActivityRegexMVPContributionArea
-    if ((($MVPContributionArea).Count -eq 0) -and ($CommandParameters -notcontains 'ContributionArea')) {
+    if ((($MVPContributionArea).Count -eq 0) -and ($null -eq $ArgumentList.ContributionArea)) {
         Throw $LocalizedData.ErrorMissingMVPActivityContributionArea
-    } elseif (($MVPContributionArea.count -eq 0) -and ($CommandParameters -contains 'ContributionArea')) {
+    } elseif (($MVPContributionArea.count -eq 0) -and ($null -ne $ArgumentList.ContributionArea)) {
         $resultObject.ParametrizedContributionArea = $true        
     } elseif (($MVPContributionArea).Count -gt 3)  {
         Throw ($LocalizedData.ErrorExceedMVPActivityContributionArea -f $MVPContributionArea.Count)
@@ -53,10 +59,57 @@ function Test-ActivityScriptBlock {
 
     # Requirement 4:
     # Ensure that the Value Cmdlet is present.
-    [Array]$valueInstance = $CommandAst -match $LocalizedData.TestActivityRegexMVPValue
-    if ($valueInstance.Count -eq 0) {
+    [Array]$valueInstances = $CommandAst -match $LocalizedData.TestActivityRegexMVPValue
+    if ($valueInstances.Count -eq 0) {
         Throw $LocalizedData.ErrorMissingMVPActivityValue
     }
+
+
+    # Requirement 5:
+    # Ensure that all values are correct according to the Area
+
+    $ValuesAddedToScriptblock = [System.Collections.Generic.List[String]]::New()
+
+    $valueInstancesWithParameterNames,$valueInstancesWithoutParameterNames = $valueInstances.Where({
+        $_.CommandElements.Where{$_.ParameterName}
+    }, 'Split')
+
+    # Return a list of cmdlet's that have parsed parameters into the input and capture their values
+    forEach ($valueInstance in $valueInstancesWithParameterNames) {
+
+        $Result = 0..$valueInstance.CommandElements.count | Where-Object { 
+            ($valueInstance.CommandElements[$_].ParameterName -eq "Name") 
+        }
+
+        # Get the following item in the array, which will be the value of the parameter name
+        $ValuesAddedToScriptblock.Add($valueInstance.CommandElements[$Result+1].Value)
+
+    }
+
+    $valueInstancesWithoutParameterNames | ForEach-Object { $ValuesAddedToScriptblock.Add( $_.CommandElements[1].Value )  }
+
+    # Get the HTMLFormStructure and Test for the
+    $HTMLFormStructure = Get-HTMLFormStructure -Name $AreaValue
+
+    $testMandatoryValues = $HTMLFormStructure | Where-Object { (
+        ($_.isRequired) -and 
+        (
+            ($_.Name -notin $ValuesAddedToScriptblock) -and 
+            ($_.Element -notin $ValuesAddedToScriptblock)
+        )    
+    )}
+
+    $testMisnamedValues = $ValuesAddedToScriptblock | Where-Object {
+        $_ -notin $HTMLFormStructure.Name -and 
+        $_ -notin $HTMLFormStructure.Element
+    }
+
+    if ($testMandatoryValues -or $testMisnamedValues) {
+        Throw ($LocalizedData.ErrorPreParseValueCheck -f $AreaValue)
+    }
+
+    #
+    # Finished
 
     Write-Output $resultObject
     

--- a/Module/Functions/Private/Test-ActivityScriptBlock.ps1
+++ b/Module/Functions/Private/Test-ActivityScriptBlock.ps1
@@ -43,7 +43,7 @@ function Test-ActivityScriptBlock {
         # Multiple Statements of Area was defined
         Throw $LocalizedData.ErrorMissingMVPActivityAreaMultiple
     } elseif (($areaInstance.count -ne 0) -and ($null -eq $ArgumentList.Area)) {
-        $AreaValue = Get-InstanceValues -InstanceValues $areaInstance  
+        $AreaValue = Get-ASTInstanceValues -InstanceValues $areaInstance -ParameterName 'Name'
     }
 
     # Requirement 3:
@@ -68,7 +68,7 @@ function Test-ActivityScriptBlock {
     # Ensure that all Values added to the fixture are (required) AND are correct
 
     $HTMLFormStructure = Get-HTMLFormStructure -Name $AreaValue
-    $ASTInstanceValues = Get-InstanceValues -InstanceValues $valueInstances
+    $ASTInstanceValues = Get-ASTInstanceValues -InstanceValues $valueInstances -ParameterName 'Name'
 
     $testMandatoryValues = $HTMLFormStructure | Where-Object { (
         ($_.isRequired) -and 

--- a/Module/Resources/03_LocalizedData.ps1
+++ b/Module/Resources/03_LocalizedData.ps1
@@ -34,6 +34,7 @@ data LocalizedData {
     ErrorTestCSVSchemaMissingColumns=Error. Validation Failed: Missing Columns '{0}'
     ErrorTestCSVSchemaDifferentAreaColumn=Formatting Error. Validation Failed: Cannot have different Areas ('{0}') within the same CSV File.
     ErrorTestCSVSchemaDuplicateContributionArea=Duplicate Contribution Area Found with SecondContributionArea and ThirdContributionArea columns within the CSV File. Please correct this issue and try again!
+    ErrorPreParseValueCheck=Preparse Check Failed. Please ensure that 'Value' has the correct names added that are appropriate for the respective 'Area'. Please run "Get-AreaNamedValues -AreaName '{0}'" to get correct 'Value' names.
     WarningEntryWasNotSaved=An Error occured when attempting to add the entry. THE ENTRY WAS NOT SAVED.
     ElementIdActivityType=activityTypeSelector 
     ElementIdContributionArea=select_contributionAreasDDL

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ OR
         ContributionArea 'Yammer'
         ContributionArea 'Word'
 
-        Value 'Date' '08/05/2021'
+        Value -Name 'Date' -Value '08/05/2021'
         Value 'Title' 'TEST'
         Value 'URL' 'https:\\test.com'
         Value 'Description' 'THIS IS A TEST'

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ MVPActivity -CSVPath 'Path to CSV File'
 ```
 
 Example CSV File:
+
 ``` CSV
 Date,Title,URL,Description,Number of Articles,Number of Views,Area,ContributionArea,SecondContributionArea,ThirdContributionArea
 28/11/2020,TEST,https://www.google.com,TEST,1,1,Article,PowerShell,Networking,Storage
@@ -95,6 +96,7 @@ Date,Title,URL,Description,Number of Articles,Number of Views,Area,ContributionA
 
    }
 ```
+
 ### Usage
 
 ``` PowerShell
@@ -105,16 +107,15 @@ Date,Title,URL,Description,Number of Articles,Number of Views,Area,ContributionA
         # ContributionArea can accept an Array
         ContributionArea 'PowerShell','Yammer','Word'
 
-        Value 'Date' $date
+        Value 'Date' '08/05/2021'
         Value 'Title' 'TEST'
         Value 'URL' 'https:\\test.com'
         Value 'Description' 'THIS IS A TEST'
-        Value 'Number of Posts' '1'
+        Value 'Number of Articles' '1'
         # Or you can use the HTML DivId
-        Value 'Number of Subscribers' '1'
-        Value 'Annual Unique Visitors' '1'
-
+        Value 'Number of Views' 1
     }
+
 ```
 
 OR
@@ -129,17 +130,17 @@ OR
         ContributionArea 'Yammer'
         ContributionArea 'Word'
 
-        Value 'Date' $date
+        Value 'Date' '08/05/2021'
         Value 'Title' 'TEST'
         Value 'URL' 'https:\\test.com'
         Value 'Description' 'THIS IS A TEST'
-        Value 'Number of Posts' '1'
+        Value 'Number of Articles' '1'
         # Or you can use the HTML DivId
-        Value 'Number of Subscribers' '1'
-        Value 'Annual Unique Visitors' '1'
+        Value 'Number of Views' 1
 
     }
 ```
+
 ### Advanced Usage
 
 ``` PowerShell
@@ -237,7 +238,7 @@ For Example:
 ```PowerShell
 
 MVPActivity "Personal Blogs" {
-    Area 'Article'
+    Area 'Blog/Website Post'
     ContributionArea 'PowerShell'
     Value 'Date' '19/11/2020'
     Value 'Title' 'TEST'
@@ -250,7 +251,7 @@ MVPActivity "Personal Blogs" {
 }
 
 MVPActivity "Another Random Blog" {
-    Area 'Article'
+    Area 'Blog/Website Post'
     ContributionArea 'PowerShell'
     Value 'Date' '19/11/2020'
     Value 'Title' 'TEST2'
@@ -272,7 +273,7 @@ Now we can refactor this logic to take advantage of the `-ArgumentList` paramete
 
 $arguments = @(
     @{
-        Area = 'Article'
+        Area = 'Blog/Website Post'
         ContributionArea = 'PowerShell'
         Date = '19/11/2020'
         Title = 'TEST'
@@ -283,7 +284,7 @@ $arguments = @(
         NumberOfVisitors = 1
     },
     @{
-        Area = 'Article'
+        Area = 'Blog/Website Post'
         ContributionArea = 'PowerShell'
         Date = '19/11/2020'
         Title = 'TEST2'
@@ -317,7 +318,7 @@ The code block can be refactored further. The DSL enables automatic Area and Con
 
 $arguments = @(
     @{
-        Area = 'Article'
+        Area = 'Blog/Website Post'
         ContributionArea = 'PowerShell'
         Date = '19/11/2020'
         Title = 'TEST'
@@ -328,7 +329,7 @@ $arguments = @(
         NumberOfVisitors = 1
     },
     @{
-        Area = 'Article'
+        Area = 'Blog/Website Post'
         ContributionArea = 'PowerShell'
         Date = '19/11/2020'
         Title = 'TEST2'

--- a/Tests/Private/Get-ASTInstanceValues.tests.ps1
+++ b/Tests/Private/Get-ASTInstanceValues.tests.ps1
@@ -1,0 +1,55 @@
+Describe 'Get-ASTInstanceValues' {
+
+    $params = @(
+        @{
+            Fixture = { MockCmdlet 'Mock-Value' }
+            Expect = 'Mock-Value'
+        }
+        @{
+            Fixture = { MockCmdlet -Name 'Mock-Value' }
+            Expect = 'Mock-Value'
+        }
+        @{
+            Fixture = { 
+                MockCmdlet -Name 'Mock-Value' 
+                AnotherMockCmdlet 'Mock-Value2'
+            }
+            Expect = 'Mock-Value','Mock-Value2'
+        }
+        @{
+            Fixture = { 
+                MockCmdlet 'Mock-Value' 
+                AnotherMockCmdlet 'Mock-Value2'
+            }
+            Expect = 'Mock-Value','Mock-Value2'
+        }
+        @{
+            Fixture = { 
+                MockCmdlet 'Mock-Value' 
+                AnotherMockCmdlet 'Mock-Value2'
+                AnotherMockCmdlet 'Mock-Value3'
+            }
+            Expect = 'Mock-Value','Mock-Value2', 'Mock-Value3'
+        },
+        @{
+            Fixture = { 
+                MockCmdlet 'Mock-Value' 
+                AnotherMockCmdlet 'Mock-Value2'
+                AnotherMockCmdlet -Mock 'Mock-Value3'
+            }
+            Expect = 'Mock-Value','Mock-Value2', 'Mock-Value3'
+        }                             
+    )
+
+    it "Should return the mock value when parsed a scriptblock" -TestCases $params {
+        param($Fixture, $Expect)
+
+        # Return a list of Commands
+        $CommandAst = $Fixture.ast.FindAll({$args[0] -is [System.Management.Automation.Language.CommandAst]}, $true)
+
+        $Result = Get-ASTInstanceValues -InstanceValues $CommandAst
+        $Result | Should -be $Expect
+
+    }
+
+}

--- a/Tests/Private/Get-ASTInstanceValues.tests.ps1
+++ b/Tests/Private/Get-ASTInstanceValues.tests.ps1
@@ -2,12 +2,22 @@ Describe 'Get-ASTInstanceValues' {
 
     $params = @(
         @{
+            Fixture = { 
+                MockCmdlet 'Mock-Value' 
+                AnotherMockCmdlet 'Mock-Value2'
+                AnotherMockCmdlet -Mock 'Mock-Value3'
+            }
+            Expect =  'Mock-Value3','Mock-Value','Mock-Value2'
+            ParameterName = 'Mock'
+        }        
+        @{
             Fixture = { MockCmdlet 'Mock-Value' }
             Expect = 'Mock-Value'
         }
         @{
             Fixture = { MockCmdlet -Name 'Mock-Value' }
             Expect = 'Mock-Value'
+            ParameterName = 'Name'
         }
         @{
             Fixture = { 
@@ -15,6 +25,7 @@ Describe 'Get-ASTInstanceValues' {
                 AnotherMockCmdlet 'Mock-Value2'
             }
             Expect = 'Mock-Value','Mock-Value2'
+            ParameterName = 'Name'
         }
         @{
             Fixture = { 
@@ -30,24 +41,21 @@ Describe 'Get-ASTInstanceValues' {
                 AnotherMockCmdlet 'Mock-Value3'
             }
             Expect = 'Mock-Value','Mock-Value2', 'Mock-Value3'
-        },
-        @{
-            Fixture = { 
-                MockCmdlet 'Mock-Value' 
-                AnotherMockCmdlet 'Mock-Value2'
-                AnotherMockCmdlet -Mock 'Mock-Value3'
-            }
-            Expect = 'Mock-Value','Mock-Value2', 'Mock-Value3'
-        }                             
+        }                            
     )
 
-    it "Should return the mock value when parsed a scriptblock" -TestCases $params {
-        param($Fixture, $Expect)
+    it "Should return the mock value when parsed a ScriptBlock" -TestCases $params {
+        param($Fixture, $Expect, $ParameterName)
 
         # Return a list of Commands
         $CommandAst = $Fixture.ast.FindAll({$args[0] -is [System.Management.Automation.Language.CommandAst]}, $true)
 
-        $Result = Get-ASTInstanceValues -InstanceValues $CommandAst
+        $params = @{
+            InstanceValues = $CommandAst            
+        }
+        if ($ParameterName) {$params.ParameterName = $ParameterName}
+
+        $Result = Get-ASTInstanceValues @params
         $Result | Should -be $Expect
 
     }


### PR DESCRIPTION
Fixed Issues with Documentation on Readme.md, correcting incorrect examples.
Added a preparser to validate the MVP activity prior to execution of the activity.